### PR TITLE
reactivate and fix test for normal distribution

### DIFF
--- a/test/tc_norm.rb
+++ b/test/tc_norm.rb
@@ -1,14 +1,14 @@
-$:.unshift File.join(File.dirname(__FILE__), "..", "lib")
+$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 require 'minitest/autorun'
 require 'rubystats/normal_distribution'
 
 class TestNormal < MiniTest::Unit::TestCase
-  def test_simple
+  def test_cdf
 
     norm = Rubystats::NormalDistribution.new(10,2)
     cdf = norm.cdf(11)
 
-    assert_equal("0.691462461274013",cdf.to_s)
-    assert_not_nil(norm.rng)
+    assert_equal('0.691462461274013', '%.15f' % cdf)
+    refute_nil(norm.rng)
   end
 end


### PR DESCRIPTION
- renamed test because it was overwritten in tc_require_all.rb
- set significant digits for assertion
- change double quoted strings to single quotes
- change assert_not_nil to refute_nil
