### PR TITLE
Add license info to the gemspec.

### DIFF
--- a/rubystats.gemspec
+++ b/rubystats.gemspec
@@ -4,6 +4,7 @@ require 'rubystats/version'
 Gem::Specification.new do |s|
   s.name        = 'rubystats'
   s.version     = Rubystats::VERSION
+  s.license     = "MIT"
   s.summary     = ''
   s.description = "Ruby Stats is a port of the statistics libraries from PHPMath. Probability distributions include binomial, beta, and normal distributions with PDF, CDF and inverse CDF as well as Fisher's Exact Test."
 


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.
