### PR TITLE
Preserve the old API by setting constants manually

### DIFF
--- a/lib/rubystats.rb
+++ b/lib/rubystats.rb
@@ -6,7 +6,10 @@ require 'rubystats/exponential_distribution'
 require 'rubystats/version'
 
 module Rubystats
-
 end
 
-include Rubystats
+NormalDistribution = Rubystats::NormalDistribution
+BinomialDistribution = Rubystats::BinomialDistribution
+BetaDistribution = Rubystats::BetaDistribution
+FishersExactTest = Rubystats::FishersExactTest
+ExponentialDistribution = Rubystats::ExponentialDistribution

--- a/lib/rubystats/version.rb
+++ b/lib/rubystats/version.rb
@@ -1,3 +1,3 @@
 module Rubystats
-  VERSION = '0.2.5'
+  VERSION = '0.2.6'
 end


### PR DESCRIPTION
When we were doing `include Rubystats`, it was including `Rubystats` on
`Object`. This is a way to preserve the old API, without adding an
ancestor every object.

Prior:

```ruby
irb(main):001:0> Object.ancestors
=> [Object, Kernel, BasicObject]
irb(main):002:0> require "rubystats"
=> true
irb(main):003:0> Object.ancestors
=> [Object, Rubystats, Kernel, BasicObject]
```

After:

```ruby
irb(main):001:0> Object.ancestors
=> [Object, Kernel, BasicObject]
irb(main):002:0> require "rubystats"
=> true
irb(main):003:0> Object.ancestors
=> [Object, Kernel, BasicObject]
```

I could definitely be missing a reason to do `include Rubystats` on `Object`, but I think this does the same thing, if not a little more verbose. There's probably a more succinct way to do this, so taking suggestions 😅 

Thanks!