### PR TITLE
Corrected PDF calculation in README.rdoc and added support to sample from beta distribution

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -49,7 +49,7 @@ Also includes Fisher's Exact Test
 == SYNOPSIS:
 === Example: normal distribution with mean of 10 and standard deviation of 2
 
- norm = Rubystats::NormalDistribution.new(10, 2)
+ norm = Rubystats::NormalDistribution.new(10.0, 2.0)
  cdf = norm.cdf(11)
  pdf = norm.pdf(11)
  puts "CDF(11): #{cdf}"
@@ -57,7 +57,7 @@ Also includes Fisher's Exact Test
 
 Output:
  CDF(11): 0.691462461274013
- PDF(11): 0.0733813315868699
+ PDF(11): 0.17603266338214973
 
 === Example: get some random numbers from a normal distribution
 

--- a/lib/rubystats/beta_distribution.rb
+++ b/lib/rubystats/beta_distribution.rb
@@ -85,9 +85,9 @@ module Rubystats
       end
     end
 
-	def rng
-	  self.icdf(rand)
-	end
+    def rng
+      self.icdf(rand)
+    end
 	
   end
 end

--- a/lib/rubystats/beta_distribution.rb
+++ b/lib/rubystats/beta_distribution.rb
@@ -85,5 +85,9 @@ module Rubystats
       end
     end
 
+	def rng
+	  self.icdf(rand)
+	end
+	
   end
 end

--- a/test/tc_beta.rb
+++ b/test/tc_beta.rb
@@ -96,5 +96,19 @@ class TestBeta < MiniTest::Unit::TestCase
     ucl=bin.icdf(1-alpha)
     return ucl
   end
+  
+  def test_rng_distribution
+	p = 4.0
+    q = 12.0
+    beta = Rubystats::BetaDistribution.new(p,q)
+	
+	total = 10000
+	values = Array.new(total).map{ beta.rng }
 
+	#mean = p / (p + q) = 4.0 / 16.0 = 0.25
+	mean = values.inject(0.0) {|sum,v| sum + v} / values.size
+	assert_in_epsilon 0.25, mean.round(2), 0.01
+	
+  end
+  
 end

--- a/test/tc_beta.rb
+++ b/test/tc_beta.rb
@@ -98,17 +98,15 @@ class TestBeta < MiniTest::Unit::TestCase
   end
   
   def test_rng_distribution
-	p = 4.0
+    p = 4.0
     q = 12.0
     beta = Rubystats::BetaDistribution.new(p,q)
 	
-	total = 10000
-	values = Array.new(total).map{ beta.rng }
+    total = 10000
+    values = Array.new(total).map{ beta.rng }
 
-	#mean = p / (p + q) = 4.0 / 16.0 = 0.25
-	mean = values.inject(0.0) {|sum,v| sum + v} / values.size
-	assert_in_epsilon 0.25, mean.round(2), 0.01
-	
+    mean = values.inject(0.0) {|sum,v| sum + v} / values.size
+    assert_in_epsilon 0.25, mean.round(2), 0.01	
   end
   
 end


### PR DESCRIPTION
The correct PDF of a normal distribution with mean = 10 and sd = 2 at x = 11 is 0.1760. The reason why it was wrong before seems to be some nasty integer calculation. 
