### PR TITLE
Remove broken RUBY_VERSION check from gemspec

### DIFF
--- a/rubystats.gemspec
+++ b/rubystats.gemspec
@@ -20,11 +20,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("minitest", ">= 4.2", "< 5.0")
   s.add_development_dependency("hoe", ">= 1.7.0")
-  if RUBY_VERSION >= "3.1"
-    # matrix was removed from default gems in Ruby 3.1, see
-    # https://github.com/ruby/ruby/pull/4530 and https://stdgems.org/
-    s.add_runtime_dependency("matrix")
-  end
 
+  # matrix was removed from default gems in Ruby 3.1, see
+  # https://github.com/ruby/ruby/pull/4530 and https://stdgems.org/
+  s.add_runtime_dependency("matrix")
 end
 


### PR DESCRIPTION
- See discussion in https://github.com/phillbaker/rubystats/pull/20
- Tested in projects with Ruby versions 3.0.6 (i.e. < 3.1) and 3.2.2 (i.e. >= 3.1)
  - Updated my gemspec to point to High5Apps/rubystats
  - Created a new docker container at each version with my project that uses rubystats
  - Verified that tests passed and rubystats worked as expected after `bundle install`